### PR TITLE
Use replace mode of embulk-output-bigquery

### DIFF
--- a/lib/naginegi/bigquery.rb
+++ b/lib/naginegi/bigquery.rb
@@ -19,6 +19,7 @@ module Naginegi
       <%= options %>
     out:
       type: bigquery
+      mode: replace
       auth_method: <%= auth_method %>
       json_keyfile: <%= json_keyfile %>
         <%= json_key_content %>


### PR DESCRIPTION
```
Could not load the default credentials.
```
This problem occurs frequently when drop table to modify table schema.  
To avoid duplicate record, use `replace` mode of embulk-output-bigquery.  

### reference
https://github.com/embulk/embulk-output-bigquery#mode